### PR TITLE
Updated salt minion installation commands

### DIFF
--- a/geoping-pipeline.py
+++ b/geoping-pipeline.py
@@ -13,7 +13,7 @@ from botocore.exceptions import NoCredentialsError
 parser = argparse.ArgumentParser()
 parser.add_argument("--regex", type=str, default="aws-us-east-2*", help="regex for targeted vantage points")
 parser.add_argument("--launch", type=str, default="ping", help="Options to launch the experiment, ping = icmp-echo ping, ping-tcp = tcp ping, trace = traceroute")
-parser.add_argument("--flags", type=str, default="", help="add the flags you want to conduct complext tests")
+parser.add_argument("--flags", type=str, default="", help="add the flags you want to conduct complex tests")
 args = parser.parse_args()
 
 ############### PARAMETERS ###########

--- a/startup.sh
+++ b/startup.sh
@@ -24,10 +24,12 @@ fi
 
 if ! [ -x "$(command -v salt-minion)" ]; then
     echo "Salt Minion is not installed. Installing now..."
-    sudo curl -fsSL -o /etc/apt/keyrings/salt-archive-keyring-2023.gpg https://repo.saltproject.io/salt/py3/ubuntu/24.04/amd64/SALT-PROJECT-GPG-PUBKEY-2023.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/salt-archive-keyring-2023.gpg arch=amd64] https://repo.saltproject.io/salt/py3/ubuntu/24.04/amd64/latest noble main" | sudo tee /etc/apt/sources.list.d/salt.list
+    sudo mkdir -p /etc/apt/keyrings
+    sudo curl -fsSL https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public | sudo tee /etc/apt/keyrings/salt-archive-keyring.pgp
+    curl -fsSL https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.sources | sudo tee /etc/apt/sources.list.d/salt.sources
     sudo apt-get update
     sudo apt-get install -y salt-minion
+    echo "Salt Minion installed."
 fi
 # #Code to update a master
 sudo echo -e "master: $3" | sudo tee /etc/salt/minion.d/master.conf

--- a/startup.sh
+++ b/startup.sh
@@ -74,5 +74,4 @@ fi
 # bring up the instance to the VPN network
 sudo netbird up --setup-key "$2"
 
-
 sudo scamper -P 5001 -p 1500 -D && echo 'Started scamper on port 5001' && sleep 1


### PR DESCRIPTION
Salt project has moved to a new URL: package.broadcom.com

https://docs.saltproject.io/salt/install-guide/en/latest/